### PR TITLE
Fix metadata issue for echo payload

### DIFF
--- a/spec/facebook/messenger/incoming_spec.rb
+++ b/spec/facebook/messenger/incoming_spec.rb
@@ -55,7 +55,8 @@ describe Facebook::Messenger::Incoming do
             'is_echo' => true,
             'mid' => 'mid.1457764197618:41d102a3e1ae206a38',
             'seq' => 73,
-            'text' => 'Hello, bot!'
+            'text' => 'Hello, bot!',
+            'metadata' => 'metadata'
           }
         }
       end


### PR DESCRIPTION
You can add a metadata to the messages you send and get it back with the echo feature ([see documentation](https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-echo)).

This edit should allow us to retrieve this metadata? (not 100% sure about that, I'm a noob developer)